### PR TITLE
moving the download higher up the init routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Part of what makes our containers work so well is by allowing you to specify you
 
 * You must register here to recieve a musicbrainz code to allow you to recieve database updates, it is free. [Get Code here](https://metabrainz.org/supporters/account-type). 
 * The initial import and setup of the database can take quite a long time, dependant on your download speed etc, be patient and don't restart the container before it's complete.
-
+* It appears there are issues with unraid and using /mnt/user/cache/appdata instead of /mnt/cache/appdata, use /mnt/cache/appdata.
 
 ## Logs
 * To monitor the logs of the container in realtime `docker logs -f musicbrainz`.

--- a/init/40_initialise.sh
+++ b/init/40_initialise.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 
 # set some folders and permissions
 
@@ -7,8 +9,6 @@ chown abc:abc "$DATA_ROOT"
 
 mkdir -p /var/run/postgresql
 chown -R abc:abc /var/run/postgresql /app
-
-set -e
 
 set_listen_addresses() {
 	sedEscapedValue="$(echo "*" | sed 's/[\/&]/\\&/g')"

--- a/init/40_initialise.sh
+++ b/init/40_initialise.sh
@@ -34,7 +34,7 @@ echo "fetching latest dump from musicbrainz, if this section fails try again lat
 /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-stats.tar.bz2 -L -C - "$DUMP_URL"/mbdump-stats.tar.bz2
 /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-wikidocs.tar.bz2 -L -C - "$DUMP_URL"/mbdump-wikidocs.tar.bz2
 /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump.tar.bz2 -L -C - "$DUMP_URL"/mbdump.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-sitemaps.tar.bz2 -L -C - "$DUMP_URL"/mbdump-sitemaps.tar.bz2
+# /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-sitemaps.tar.bz2 -L -C - "$DUMP_URL"/mbdump-sitemaps.tar.bz2
 # /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-edit.tar.bz2 -L -C - "$DUMP_URL"/mbdump-edit.tar.bz2
 
 echo "initialising empty databases"

--- a/init/40_initialise.sh
+++ b/init/40_initialise.sh
@@ -19,6 +19,24 @@ set_listen_addresses() {
 if [ ! -s "$PGDATA/PG_VERSION" ]; then
 chown -R abc:abc "$DATA_ROOT"
 
+dumpver=$(curl -s $URL_ROOT/LATEST)
+DUMP_URL="$URL_ROOT"/"$dumpver"
+DUMP_DEST="$MBDATA"/"$dumpver"
+mkdir -p "$DUMP_DEST"
+chown abc:abc "$DUMP_DEST"
+echo "fetching latest dump from musicbrainz, if this section fails try again later as musicbrainz dump may not be fully uploaded to their site"
+
+# /sbin/setuser abc curl -o "$DUMP_DEST"/MD5SUMS -L -C - "$DUMP_URL"/MD5SUMS
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-cdstubs.tar.bz2 -L -C - "$DUMP_URL"/mbdump-cdstubs.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-cover-art-archive.tar.bz2 -L -C - "$DUMP_URL"/mbdump-cover-art-archive.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-derived.tar.bz2 -L -C - "$DUMP_URL"/mbdump-derived.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-editor.tar.bz2 -L -C - "$DUMP_URL"/mbdump-editor.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-stats.tar.bz2 -L -C - "$DUMP_URL"/mbdump-stats.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-wikidocs.tar.bz2 -L -C - "$DUMP_URL"/mbdump-wikidocs.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump.tar.bz2 -L -C - "$DUMP_URL"/mbdump.tar.bz2
+/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-sitemaps.tar.bz2 -L -C - "$DUMP_URL"/mbdump-sitemaps.tar.bz2
+# /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-edit.tar.bz2 -L -C - "$DUMP_URL"/mbdump-edit.tar.bz2
+
 echo "initialising empty databases"
 /sbin/setuser abc initdb >/dev/null 2>&1
 echo "completed postgres initialise"
@@ -35,23 +53,6 @@ sleep 5s
 sleep 5s
 echo "BEGINNING INITIAL DATABASE IMPORT ROUTINE, THIS COULD TAKE SEVERAL HOURS AND THE DOCKER MAY LOOK UNRESPONSIVE"
 echo "DO NOT STOP DOCKER UNTIL IT IS COMPLETED"
-
-dumpver=$(curl -s $URL_ROOT/LATEST)
-DUMP_URL="$URL_ROOT"/"$dumpver"
-DUMP_DEST="$MBDATA"/"$dumpver"
-mkdir -p "$DUMP_DEST"
-chown abc:abc "$DUMP_DEST"
-
-# /sbin/setuser abc curl -o "$DUMP_DEST"/MD5SUMS -L -C - "$DUMP_URL"/MD5SUMS
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-cdstubs.tar.bz2 -L -C - "$DUMP_URL"/mbdump-cdstubs.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-cover-art-archive.tar.bz2 -L -C - "$DUMP_URL"/mbdump-cover-art-archive.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-derived.tar.bz2 -L -C - "$DUMP_URL"/mbdump-derived.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-editor.tar.bz2 -L -C - "$DUMP_URL"/mbdump-editor.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-stats.tar.bz2 -L -C - "$DUMP_URL"/mbdump-stats.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-wikidocs.tar.bz2 -L -C - "$DUMP_URL"/mbdump-wikidocs.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump.tar.bz2 -L -C - "$DUMP_URL"/mbdump.tar.bz2
-/sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-sitemaps.tar.bz2 -L -C - "$DUMP_URL"/mbdump-sitemaps.tar.bz2
-# /sbin/setuser abc curl -o "$DUMP_DEST"/mbdump-edit.tar.bz2 -L -C - "$DUMP_URL"/mbdump-edit.tar.bz2
 
 cd /app/musicbrainz
 /sbin/setuser abc ./admin/InitDb.pl --createdb --import "$DUMP_DEST"/mbdump*.tar.bz2 --tmp-dir "$DUMP_DEST" --echo


### PR DESCRIPTION
give the possibility of a resume failed transfer without having to delete the database folder.
