### PR TITLE
Disable babel cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV MBDATA="${DATA_ROOT}"/import
 ENV PGDATA="${DATA_ROOT}"/dbase
 ENV URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
 ENV POSTGRES_LOGS_FIFO="/var/run/s6/postgres-logs-fifo"
+ENV BABEL_DISABLE_CACHE="1"
 
 # copy files required in build stage
 COPY prebuilds/ /defaults/


### PR DESCRIPTION
Since the `HOME` is set to `/root`, `abc` does not have permission read / write `/root/.babel.json`, which is the babel cache file.

Which leads to following error when starting the container:

```
fs.js:565
fs.write = function(fd, buffer, offset, length, position, callback) {
                                                 ^
Error: EACCES, permission denied '/root/.babel.json'
    at Error (native)
    at Object.fs.openSync (fs.js:500:18)
    at Object.fs.writeFileSync (fs.js:1099:15)
    at save (/app/musicbrainz/node_modules/babel-register/lib/cache.js:48:19)
    at process._tickCallback (node.js:355:11)
    at Function.Module.runMain (module.js:503:11)
    at startup (node.js:129:16)
    at node.js:814:3
```

The PR simply disable babel cache. But please advice if you feel there're better ways.

Thank you.
