### PR TITLE
upgrade to node.js v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN \
 	wget && \
 
 # install nodejs and npm
- curl -sL https://deb.nodesource.com/setup_0.12 | bash - && \
+ curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
  apt-get install -y \
 	nodejs && \
  	npm install -g npm@latest && \


### PR DESCRIPTION
Node v0.12 is deprecated and  is no longer actively supported. We're seeing `DEPRECATION WARNING` during building the image.

Switch to v4. Which works fine for a very limited test.
