### PR TITLE
Use starlet to process requests in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV MBDATA="${DATA_ROOT}"/import
 ENV PGDATA="${DATA_ROOT}"/dbase
 ENV URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
 ENV POSTGRES_LOGS_FIFO="/var/run/s6/postgres-logs-fifo"
+ENV MAX_WORKERS="1"
 
 # copy files required in build stage
 COPY prebuilds/ /defaults/
@@ -78,6 +79,7 @@ RUN \
  cd /app/musicbrainz && \
 	cpanm MLEHMANN/Coro-6.49.tar.gz && \
 	cpanm --installdeps --notest . && \
+	cpanm --notest Starlet && \
 	npm install && \
 	./script/compile_resources.sh && \
 

--- a/root/etc/services.d/server/run
+++ b/root/etc/services.d/server/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 cd /app/musicbrainz
-s6-setuidgid abc plackup -Ilib -r > /dev/null 2>&1
+s6-setuidgid abc start_server --port=5000 -- plackup -I lib -s Starlet --max-workers $MAX_WORKERS > /dev/null 2>&1


### PR DESCRIPTION
This PR adds a `-e MAX_WORKERS`option which will pass to Starlet, thus increase performance on multi-core machines.

Please check the modifications, Thanks.
