### PR TITLE
fix problem with tmp socket not being removed on restart

### DIFF
--- a/root/etc/cont-init.d/20-brainzcode
+++ b/root/etc/cont-init.d/20-brainzcode
@@ -3,6 +3,8 @@
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm && -f /app/musicbrainz/lib/DBDefs.pm ]] && rm /app/musicbrainz/lib/DBDefs.pm
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm ]] && ln -s /config/DBDefs.pm /app/musicbrainz/lib/DBDefs.pm
 
+rm /tmp/musicbrainz-template-renderer.socket
+
 # sanitize brainzcode for white space
 SANEDBRAINZCODE0=$BRAINZCODE
 SANEDBRAINZCODE1="${SANEDBRAINZCODE0#"${SANEDBRAINZCODE0%%[![:space:]]*}"}"

--- a/root/etc/cont-init.d/20-brainzcode
+++ b/root/etc/cont-init.d/20-brainzcode
@@ -3,7 +3,9 @@
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm && -f /app/musicbrainz/lib/DBDefs.pm ]] && rm /app/musicbrainz/lib/DBDefs.pm
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm ]] && ln -s /config/DBDefs.pm /app/musicbrainz/lib/DBDefs.pm
 
-rm /tmp/musicbrainz-template-renderer.socket
+if [ -e /tmp/musicbrainz-template-renderer.socket ]; then
+    rm /tmp/musicbrainz-template-renderer.socket
+fi
 
 # sanitize brainzcode for white space
 SANEDBRAINZCODE0=$BRAINZCODE


### PR DESCRIPTION
sometimes per issue:
https://tickets.metabrainz.org/browse/MBS-9370

when the computer is rebooted it gives that error and the work around is deleting the socket file, it has happened to me with the latest image created db from scratch and everything, might as well have it try deleting the file on startup if it exists to be safe and avoid this problem

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

