### PR TITLE
future proofing for linting on sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
++ **30.11.17:** Remove socket on startup if exists (thanks wtf911) [re](https://tickets.metabrainz.org/browse/MBS-9370).
 + **24.11.17:** Remove catalyst side bar on new installs.
 + **31.10.17:** Bump server version 2017-10-31.
 + **20.09.17:** Bump server version 2017-09-18.

--- a/root/etc/cont-init.d/20-brainzcode
+++ b/root/etc/cont-init.d/20-brainzcode
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
+
 [[ ! -f /config/DBDefs.pm ]] && cp /defaults/DBDefs.pm /config/DBDefs.pm
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm && -f /app/musicbrainz/lib/DBDefs.pm ]] && rm /app/musicbrainz/lib/DBDefs.pm
 [[ ! -L /app/musicbrainz/lib/DBDefs.pm ]] && ln -s /config/DBDefs.pm /app/musicbrainz/lib/DBDefs.pm
@@ -11,7 +12,7 @@ fi
 SANEDBRAINZCODE0=$BRAINZCODE
 SANEDBRAINZCODE1="${SANEDBRAINZCODE0#"${SANEDBRAINZCODE0%%[![:space:]]*}"}"
 SANEDBRAINZCODE="${SANEDBRAINZCODE1%"${SANEDBRAINZCODE1##*[![:space:]]}"}"
-sed -i "s|\(sub REPLICATION_ACCESS_TOKEN\ {\ \\\"\)[^<>]*\(\\\"\ }\)|\1${SANEDBRAINZCODE}\2|" /config/DBDefs.pm
+sed -i "s|\\(sub REPLICATION_ACCESS_TOKEN\\ {\\ \\\"\\)[^<>]*\\(\\\"\\ }\\)|\\1${SANEDBRAINZCODE}\\2|" /config/DBDefs.pm
 
 # set ip for webserver
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ according to web version of shellcheck the sed will trigger a bucket load of linting warnings etc
+ added README update for last commit about socket