### PR TITLE
Adding ngx_http_sub_module for content rewrite

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -14,6 +14,10 @@ http {
 
     access_log  /config/log/nginx/access.log;
 
+    sub_filter_once off;
+    sub_filter_types *;
+    sub_filter "//localhost:5000" "";
+    
     sendfile        on;
     #tcp_nopush     on;
 


### PR DESCRIPTION
It looks like it would be easier to just remove `WEBADDRESS` variable from the configuration option and make Nginx rewrite content looking for _localhost:5000_.

We could simply add [ngx_http_sub_module](http://nginx.org/en/docs/http/ngx_http_sub_module.html) config which is already installed in this image.

Note: The `WEBADDRESS` removal is not in this patch.

PS-Thank you for your docker image