### PR TITLE
Change ENV URL_ROOT to http to allow DB initialisation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ MBDATA="/data/import" \
 PGCONF="/config" \
 PGDATA="/data/dbase" \
 UPDATE_SLAVE_LOGDIR="/config/log/musicbrainz" \
-URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
+URL_ROOT="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
 
 RUN \
  echo "**** install build packages ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -21,7 +21,7 @@ MBDATA="/data/import" \
 PGCONF="/config" \
 PGDATA="/data/dbase" \
 UPDATE_SLAVE_LOGDIR="/config/log/musicbrainz" \
-URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
+URL_ROOT="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
 
 RUN \
  echo "**** install build packages ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -21,7 +21,7 @@ MBDATA="/data/import" \
 PGCONF="/config" \
 PGDATA="/data/dbase" \
 UPDATE_SLAVE_LOGDIR="/config/log/musicbrainz" \
-URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
+URL_ROOT="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"
 
 RUN \
  echo "**** install build packages ****" && \


### PR DESCRIPTION
Closes issue #71 

The docker-musicbrainz/root/etc/cont-init.d/30-initialise-database file has a 'latest version' check:

dumpver=$(curl -s "$URL_ROOT"/LATEST)

This should set $dumpver to be the latest snapshot's directory name. Instead, the curl command freezes and fails to set the variable. It eventually times out and the snapshot fails to download.

The "$URL_ROOT" environment variable is set to:

URL_ROOT="ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"

Changing the URL_ROOT variable to use http:

URL_ROOT="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport"

...allows curl to correctly set the $dumpver variable, download the latest snapshot and initialise a new database correctly.