### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -62,6 +62,9 @@ jobs:
           if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
             echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
             exit 0
+          elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-musicbrainz/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
+            echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
+            exit 0
           else
             echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"
             response=$(curl -iX POST \

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -16,6 +16,10 @@ jobs:
             echo "**** Github secret PAUSE_PACKAGE_TRIGGER_MUSICBRAINZ_MASTER is set; skipping trigger. ****"
             exit 0
           fi
+          if [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-musicbrainz/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
+            echo "**** There already seems to be an active build on Jenkins; skipping package trigger ****"
+            exit 0
+          fi
           echo "**** Package trigger running off of master branch. To disable, set a Github secret named \"PAUSE_PACKAGE_TRIGGER_MUSICBRAINZ_MASTER\". ****"
           response=$(curl -iX POST \
             https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-musicbrainz/job/master/buildWithParameters?PACKAGE_CHECK=true \


### PR DESCRIPTION
since musicbrainz builds takes longer than an hour, it's a good idea to have the hourly external package trigger check for active builds first, so we don't fire off duplicate builds on jenkins