### PR TITLE
Revert "Add missing cpan library"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ RUN \
 	Catalyst::Plugin::Cache::HTTP \
 	Catalyst::Plugin::StackTrace \
 	Digest::MD5::File \
-	DynaLoader::Functions \
 	FCGI \
 	FCGI::ProcManager \
 	Plack::Handler::Starlet \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -85,7 +85,6 @@ RUN \
 	Catalyst::Plugin::Cache::HTTP \
 	Catalyst::Plugin::StackTrace \
 	Digest::MD5::File \
-	DynaLoader::Functions \
 	FCGI \
 	FCGI::ProcManager \
 	Plack::Handler::Starlet \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -85,7 +85,6 @@ RUN \
 	Catalyst::Plugin::Cache::HTTP \
 	Catalyst::Plugin::StackTrace \
 	Digest::MD5::File \
-	DynaLoader::Functions \
 	FCGI \
 	FCGI::ProcManager \
 	Plack::Handler::Starlet \


### PR DESCRIPTION
Reverts linuxserver/docker-musicbrainz#83

After further testing, I don't think this has worked. Although `DynaLoader:: Functions` does not exist in `linuxserver\musicbrainz` installing it does not resolve the error.

I think I actually tested this in my `linuxserver/musicbrainz:v-2019-08-08-ls6` container which doesn't have the problem.